### PR TITLE
Assets handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,39 @@ module.exports = {
 }
 ```
 
+### Asserts Handling
+
+You can transform an asset path in template to `require` expression that the webpack can handle. For example, if you would like to process image file specified on `src` attributes of `<img>` element, you should set `transformToRequire` option.
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.html$/,
+        loader: 'vue-template-loader',
+        options: {
+          transformToRequire: {
+            // The key should be element name,
+            // the value should be attribute name or its array
+            img: 'src'
+          }
+        }
+      },
+
+      // Make sure to add the loader that can process the asset files
+      {
+        test: /\.(png|jpg)/,
+        loader: 'file-loader',
+        options: {
+          // ...
+        }
+      }
+    ]
+  }
+}
+```
+
 ### Loading Scoped Styles
 
 You need to specify scoped flag and loaders for style files such as `style-loader` and `css-loader`. Note that they must be `enforce: post` to inject scope id into styles before they are processed by them.
@@ -39,7 +72,10 @@ module.exports = {
     rules: [
       {
         test: /\.html$/,
-        use: 'vue-template-loader?scoped' // add `scoped` flag
+        loader: 'vue-template-loader',
+        options: {
+          scoped: true // add `scoped` flag
+        }
       },
       {
         enforce: 'post', // required

--- a/lib/modules/template-compiler.js
+++ b/lib/modules/template-compiler.js
@@ -1,0 +1,31 @@
+const compiler = require('vue-template-compiler')
+const transpile = require('vue-template-es2015-compiler')
+
+const empty =
+  `var render = ${toFunction('')}\n` +
+  'var staticRenderFns = []'
+
+module.exports = function compile (template) {
+  const compiled = compiler.compile(template)
+
+  if (compiled.errors.length > 0) {
+    return {
+      errors: compiled.errors,
+      code: empty
+    }
+  }
+
+  const transpiled = transpile(
+    `var render = ${toFunction(compiled.render)}\n` +
+    `var staticRenderFns = [${compiled.staticRenderFns.map(toFunction).join(',')}]`
+  )
+
+  return {
+    errors: [],
+    code: transpiled
+  }
+}
+
+function toFunction (code) {
+  return `function(){${code}}`
+}

--- a/lib/modules/template-compiler.js
+++ b/lib/modules/template-compiler.js
@@ -5,8 +5,12 @@ const empty =
   `var render = ${toFunction('')}\n` +
   'var staticRenderFns = []'
 
-module.exports = function compile (template) {
-  const compiled = compiler.compile(template)
+module.exports = function compile (template, { transformToRequire = {}} = {}) {
+  const compiled = compiler.compile(template, {
+    modules: [{
+      postTransformNode: el => transformAsset(el, transformToRequire)
+    }]
+  })
 
   if (compiled.errors.length > 0) {
     return {
@@ -23,6 +27,44 @@ module.exports = function compile (template) {
   return {
     errors: [],
     code: transpiled
+  }
+}
+
+function transformAsset (el, transformToRequire) {
+  if (!el.attrs) return
+
+  Object.keys(transformToRequire).forEach(targetTag => {
+    if (el.tag !== targetTag) return
+
+    let targetAttrs = transformToRequire[targetTag]
+    el.attrs.forEach(attr => {
+      if (typeof targetAttrs === 'string') {
+        targetAttrs = [targetAttrs]
+      }
+
+      targetAttrs.forEach(targetName => {
+        if (attr.name !== targetName) return
+        rewriteAsset(attr)
+      })
+    })
+  })
+}
+
+function rewriteAsset (attr) {
+  let value = attr.value
+
+  const isStatic = value[0] === '"'
+    && value[value.length - 1] === '"'
+  if (!isStatic) {
+    return
+  }
+
+  const first = value[1]
+  if (first === '.' || first === '~') {
+    if (first === '~') {
+      value = '"' + value.slice(2)
+    }
+    attr.value = `require(${value})`
   }
 }
 

--- a/lib/template-loader.js
+++ b/lib/template-loader.js
@@ -17,7 +17,7 @@ module.exports = function (content) {
   const { style: stylePath } = loaderUtils.parseQuery('?' + this.request.split('?').pop())
   const { scoped } = loaderUtils.parseQuery(this.query)
 
-  const compiled = compile(content)
+  const compiled = compile(content, this.options)
   compiled.errors.forEach(error => {
     this.emitError('template syntax error ' + error)
   })

--- a/lib/template-loader.js
+++ b/lib/template-loader.js
@@ -17,7 +17,7 @@ module.exports = function (content) {
   const { style: stylePath } = loaderUtils.parseQuery('?' + this.request.split('?').pop())
   const options = loaderUtils.parseQuery(this.query)
 
-  const compiled = compile(content, this.query)
+  const compiled = compile(content, options)
   compiled.errors.forEach(error => {
     this.emitError('template syntax error ' + error)
   })

--- a/lib/template-loader.js
+++ b/lib/template-loader.js
@@ -15,9 +15,9 @@ module.exports = function (content) {
 
   // Acquire the query of target file
   const { style: stylePath } = loaderUtils.parseQuery('?' + this.request.split('?').pop())
-  const { scoped } = loaderUtils.parseQuery(this.query)
+  const options = loaderUtils.parseQuery(this.query)
 
-  const compiled = compile(content, this.options)
+  const compiled = compile(content, this.query)
   compiled.errors.forEach(error => {
     this.emitError('template syntax error ' + error)
   })
@@ -26,7 +26,7 @@ module.exports = function (content) {
     !this.minimize &&
     process.env.NODE_ENV !== 'production'
 
-  let output = writeRenderCode(compiled.code, id, stylePath, scoped)
+  let output = writeRenderCode(compiled.code, id, stylePath, options.scoped)
   if (shouldHotReload) {
     output += writeHotReloadCode(id)
   }

--- a/lib/template-loader.js
+++ b/lib/template-loader.js
@@ -5,34 +5,28 @@
  */
 
 const loaderUtils = require('loader-utils')
-const compiler = require('vue-template-compiler')
-const transpile = require('vue-template-es2015-compiler')
+const compile = require('./modules/template-compiler')
 const genId = require('./modules/gen-id')
 
 module.exports = function (content) {
   this.cacheable()
   const isServer = this.options.target === 'node'
-  const compiled = compiler.compile(content)
   const id = `data-v-${genId(this.resourcePath)}`
 
   // Acquire the query of target file
   const { style: stylePath } = loaderUtils.parseQuery('?' + this.request.split('?').pop())
   const { scoped } = loaderUtils.parseQuery(this.query)
 
+  const compiled = compile(content)
   compiled.errors.forEach(error => {
     this.emitError('template syntax error ' + error)
   })
-
-  const transpiled = transpile(
-    `var render = ${toFunction(compiled.render)}\n` +
-    `var staticRenderFns = [${compiled.staticRenderFns.map(toFunction).join(',')}]`
-  )
 
   const shouldHotReload = !isServer &&
     !this.minimize &&
     process.env.NODE_ENV !== 'production'
 
-  let output = writeRenderCode(transpiled, id, stylePath, scoped)
+  let output = writeRenderCode(compiled.code, id, stylePath, scoped)
   if (shouldHotReload) {
     output += writeHotReloadCode(id)
   }
@@ -100,8 +94,4 @@ function writeHotReloadCode (id) {
     '  }',
     '})()}\n'
   ].join('\n')
-}
-
-function toFunction (code) {
-  return `function(){${code}}`
 }

--- a/test/modules/template-compiler.spec.js
+++ b/test/modules/template-compiler.spec.js
@@ -1,0 +1,26 @@
+const compile = require('../../lib/modules/template-compiler')
+
+describe('template-compiler', () => {
+  it('transforms specified el\'s attr to require', () => {
+    const actual = compile('<img src="./foo.png">', {
+      transformToRequire: {
+        img: 'src'
+      }
+    })
+    expect(actual.code).toMatch(/require\("\.\/foo\.png"\)/)
+  })
+
+  it('does not transform unspecified attributes', () => {
+    const actual = compile('<img src="./foo.png">')
+    expect(actual.code).toMatch(/"src":"\.\/foo\.png"/)
+  })
+
+  it('transforms "~" to module name require', () => {
+    const actual = compile('<img src="~foo.png">', {
+      transformToRequire: {
+        img: 'src'
+      }
+    })
+    expect(actual.code).toMatch(/require\("foo\.png"\)/)
+  })
+})


### PR DESCRIPTION
This patch allows us to transform asset path in template to `require` statement as same as vue-loader.

Example configuration:

```js
rules: [
  {
    test: /\.html$/,
    use: {
      loader: 'vue-template-loader',
      options: {
        scoped: true,
        transformToRequire: { 
          img: 'src'
        }
      }
    }
  }
]
```

Fix #11 