### PR TITLE
Explicitly disable HMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,32 @@ module.exports = {
 }
 ```
 
+### Disabling HMR
+
+By default Hot Module Replacement is disabled in following situations:
+
+ * Webpack `target` is `node`
+ * Webpack doesn't minify the code 
+ * `process.env.NODE_ENV !== 'production'`
+  
+You may use `hmr: false` option to disable HMR explicitly for any other situation.
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.html$/,
+        loader: 'vue-template-loader',
+        options: {
+          hmr: false // disables Hot Modules Replacement
+        }
+      }
+    ]
+  }
+}
+```
+
 ## Example
 
 Write a template of Vue component as html.

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ module.exports = {
 By default Hot Module Replacement is disabled in following situations:
 
  * Webpack `target` is `node`
- * Webpack doesn't minify the code 
- * `process.env.NODE_ENV !== 'production'`
+ * Webpack minifies the code
+ * `process.env.NODE_ENV === 'production'`
   
 You may use `hmr: false` option to disable HMR explicitly for any other situation.
 

--- a/lib/template-loader.js
+++ b/lib/template-loader.js
@@ -16,17 +16,17 @@ module.exports = function (content) {
   // Acquire the query of target file
   const { style: stylePath } = parseQuery(this.request.split('?').pop())
   const options = loaderUtils.getOptions(this) || {}
+  const isHmrEnabled = options.hmr !== false
 
   const compiled = compile(content, options)
   compiled.errors.forEach(error => {
     this.emitError('template syntax error ' + error)
   })
 
-  const shouldHotReload = !isServer &&
-    !this.minimize &&
+  const shouldHotReload = isHmrEnabled && !isServer && !this.minimize &&
     process.env.NODE_ENV !== 'production'
 
-  let output = writeRenderCode(compiled.code, id, stylePath, options.scoped)
+  let output = writeRenderCode(compiled.code, id, stylePath, options.scoped, shouldHotReload)
   if (shouldHotReload) {
     output += writeHotReloadCode(id)
   }
@@ -34,7 +34,7 @@ module.exports = function (content) {
   return output
 }
 
-function writeRenderCode (compiled, id, stylePath, isScoped) {
+function writeRenderCode (compiled, id, stylePath, isScoped, shouldHotReload) {
   return [
     writeInjectStyle(stylePath, isScoped, id),
     compiled,
@@ -45,9 +45,7 @@ function writeRenderCode (compiled, id, stylePath, isScoped) {
     writeInjectCssModules(stylePath),
     '  options.render = render',
     '  options.staticRenderFns = staticRenderFns',
-    '  if (module.hot && api) {',
-    `    api.createRecord("${id}", options)`,
-    '  }',
+    writeHotReloadCreateRecord(id, shouldHotReload),
     '  return _exports',
     '}\n'
   ].join('\n')
@@ -79,6 +77,16 @@ function writeInjectCssModules (isEnabled) {
     '    options.computed.$style = function () { return styles }',
     '  }'
   ].join('\n')
+}
+
+function writeHotReloadCreateRecord (id, shouldHotReload) {
+  return shouldHotReload
+    ? [
+      '  if (module.hot && api) {',
+      `    api.createRecord("${id}", options)`,
+      '  }'
+    ].join('\n')
+    : ''
 }
 
 function writeHotReloadCode (id) {


### PR DESCRIPTION
Hello!

We use in our codebase HMR at another abstraction level and `vue-template-loader` by using `module.hot.accept()` prevents our HMR behavior.

I added `hmr: false` option and documented when HMR is disabled.