### PR TITLE
Leave vue-template-compiler to peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "postcss": "^5.2.15",
     "postcss-selector-parser": "^2.2.3",
     "vue-hot-reload-api": "^2.0.11",
-    "vue-template-compiler": "^2.2.1",
     "vue-template-es2015-compiler": "^1.5.1"
   },
   "devDependencies": {
@@ -56,6 +55,10 @@
     "typescript": "^2.2.1",
     "vue": "^2.2.4",
     "vue-class-component": "^5.0.0",
+    "vue-template-compiler": "^2.2.1",
     "webpack": "^2.2.1"
+  },
+  "peerDependencies": {
+    "vue-template-compiler": "^2.0.0"
   }
 }


### PR DESCRIPTION
This allows the users to choose the version of vue-template-compiler. It can avoid version inconsistency between Vue and vue-template-compiler in userland.