### PR TITLE
Support :global pseudo class

### DIFF
--- a/lib/modules/add-scoped-id.js
+++ b/lib/modules/add-scoped-id.js
@@ -6,24 +6,29 @@ function isGlobalNode (node) {
   return node.type === 'pseudo' && node.toString() === ':global'
 }
 
-function isGlobalSelector (selector) {
-  let isGlobal = false
-  selector.each(n => {
-    if (isGlobalNode(n)) isGlobal = true
-  })
-  return isGlobal
-}
-
-function removeGlobalSelector (selector) {
+function removeGlobalNode (selector) {
   selector.each(n => {
     if (isGlobalNode(n)) n.remove()
   })
 }
 
+/**
+ * Get the target node for adding the scoped attribute.
+ * If there is :global class, the target is a node before it.
+ * Otherwise it is the end selector.
+ */
 function getTargetNode (selector) {
+  let prev = null
   let node = null
   selector.each(n => {
-    if (n.type !== 'pseudo') node = n
+    if (n.type !== 'pseudo' && n.type !== 'combinator') {
+      node = n
+    } else if (n.type === 'combinator') {
+      prev = node
+    } else if (isGlobalNode(n)) {
+      node = prev
+      return false
+    }
   })
   return node
 }
@@ -34,16 +39,15 @@ const addScopedIdPlugin = postcss.plugin('add-scoped-id', options => {
 
   const selectorTransformer = selectorParser(selectors => {
     selectors.each(selector => {
-      // Skip if there is a :global pseudo class in the selector
-      if (isGlobalSelector(selector)) {
-        removeGlobalSelector(selector)
-        return
+      const target = getTargetNode(selector)
+
+      if (target) {
+        selector.insertAfter(target, selectorParser.attribute({
+          attribute: options.id
+        }))
       }
 
-      const target = getTargetNode(selector)
-      selector.insertAfter(target, selectorParser.attribute({
-        attribute: options.id
-      }))
+      removeGlobalNode(selector)
     })
   })
 

--- a/lib/modules/add-scoped-id.js
+++ b/lib/modules/add-scoped-id.js
@@ -2,6 +2,24 @@ const assert = require('assert')
 const postcss = require('postcss')
 const selectorParser = require('postcss-selector-parser')
 
+function isGlobalNode (node) {
+  return node.type === 'pseudo' && node.toString() === ':global'
+}
+
+function isGlobalSelector (selector) {
+  let isGlobal = false
+  selector.each(n => {
+    if (isGlobalNode(n)) isGlobal = true
+  })
+  return isGlobal
+}
+
+function removeGlobalSelector (selector) {
+  selector.each(n => {
+    if (isGlobalNode(n)) n.remove()
+  })
+}
+
 function getTargetNode (selector) {
   let node = null
   selector.each(n => {
@@ -16,6 +34,12 @@ const addScopedIdPlugin = postcss.plugin('add-scoped-id', options => {
 
   const selectorTransformer = selectorParser(selectors => {
     selectors.each(selector => {
+      // Skip if there is a :global pseudo class in the selector
+      if (isGlobalSelector(selector)) {
+        removeGlobalSelector(selector)
+        return
+      }
+
       const target = getTargetNode(selector)
       selector.insertAfter(target, selectorParser.attribute({
         attribute: options.id

--- a/test/modules/add-scoped-id.spec.js
+++ b/test/modules/add-scoped-id.spec.js
@@ -91,6 +91,24 @@ describe('add scoped id module', () => {
       done()
     })
   })
+
+  it('should not scope when :global pseudo class is included', done => {
+    test(
+      'data-v-1',
+      [
+        ':global p {}',
+        'div :global p {}',
+        'h1 :global {}',
+        'ul:global {}'
+      ].join('\n'),
+      [
+        ' p {}',
+        'div  p {}',
+        'h1  {}',
+        'ul {}'
+      ].join('\n')
+    ).then(done)
+  })
 })
 
 function test (id, input, expected, map) {

--- a/test/modules/add-scoped-id.spec.js
+++ b/test/modules/add-scoped-id.spec.js
@@ -92,20 +92,52 @@ describe('add scoped id module', () => {
     })
   })
 
-  it('should not scope when :global pseudo class is included', done => {
+  it('should not scope when there is :global pseudo class in ancestors', done => {
     test(
       'data-v-1',
       [
         ':global p {}',
-        'div :global p {}',
-        'h1 :global {}',
-        'ul:global {}'
+        ':global ul li {}'
       ].join('\n'),
       [
         ' p {}',
-        'div  p {}',
-        'h1  {}',
-        'ul {}'
+        ' ul li {}'
+      ].join('\n')
+    ).then(done)
+  })
+
+  it('should not scope selector having :global pseudo class', done => {
+    test(
+      'data-v-1',
+      '.foo:global {}',
+      '.foo {}'
+    ).then(done)
+  })
+
+  it('should scope parent node of :global pseudo class', done => {
+    test(
+      'data-v-1',
+      [
+        '.foo .bar :global .baz {}',
+        '.foo .bar:global {}'
+      ].join('\n'),
+      [
+        '.foo .bar[data-v-1]  .baz {}',
+        '.foo[data-v-1] .bar {}'
+      ].join('\n')
+    ).then(done)
+  })
+
+  it('should not add scope attribute to combinator', done => {
+    test(
+      'data-v-1',
+      [
+        '.foo + :global .bar {}',
+        '.foo :global > .bar {}'
+      ].join('\n'),
+      [
+        '.foo[data-v-1] +  .bar {}',
+        '.foo[data-v-1]  > .bar {}'
       ].join('\n')
     ).then(done)
   })


### PR DESCRIPTION
Fix #23 

This introduces `:global` pseudo class for scoped-style-loader. If css selector includes `:global`, the selector no longer scoped.

Input:
```css
:global h1 p {
  color: red;
}

h1 p {
  color: blue;
}
```

Output:
```css
h1 p {
  color: red;
}

h1 p[data-v-xxx] {
  color: blue;
}
```

This syntax would be more convenient if we use css preprocessor like Sass.

Input:
```scss
.foo {
  color: red;

  :global {
    color: cyan;

    .bar {
      color: blue;
    }
  }
}
```

Output:
```css
.foo[data-v-xxx] {
  color: red;
}

.foo {
  color: cyan;
}

.foo .bar {
  color: blue;
}
```