### PR TITLE
Utilize deep combinator instead of :global

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,26 @@ module.exports = {
 }
 ```
 
+#### `>>>` combinator
+
+There are cases you may want to style children components. e.g. using a third party component. In such cases, you can use `>>>` combinator to apply styles to any descendant elements of a scoped styled element.
+
+Input:
+
+```css
+.foo >>> .bar {
+  color: red;
+}
+```
+
+Output:
+
+```css
+.foo[data-v-4fd8d954] .bar {
+  color: red
+}
+```
+
 ### Loading CSS Modules
 
 All what you have to do is enable `modules` flag of `css-loader`. vue-template-loader will add `$style` property and you can use hashed classes through it.

--- a/lib/modules/add-scoped-id.js
+++ b/lib/modules/add-scoped-id.js
@@ -2,31 +2,34 @@ const assert = require('assert')
 const postcss = require('postcss')
 const selectorParser = require('postcss-selector-parser')
 
-function isGlobalNode (node) {
-  return node.type === 'pseudo' && node.toString() === ':global'
+function isDeepCombinator (node) {
+  return node.type === 'combinator' && node.toString().trim() === '>>>'
 }
 
-function removeGlobalNode (selector) {
+function replaceDeepCombinator (selector) {
   selector.each(n => {
-    if (isGlobalNode(n)) n.remove()
+    if (isDeepCombinator(n)) {
+      // Use descendant combinator instead of deep combinator
+      n.replaceWith(selectorParser.combinator({
+        value: ' '
+      }))
+    }
   })
 }
 
 /**
  * Get the target node for adding the scoped attribute.
- * If there is :global class, the target is a node before it.
- * Otherwise it is the end selector.
+ * If there is >>> combinator, the target is a selector before it.
+ * Otherwise it is the last selector.
  */
 function getTargetNode (selector) {
-  let prev = null
   let node = null
   selector.each(n => {
     if (n.type !== 'pseudo' && n.type !== 'combinator') {
       node = n
-    } else if (n.type === 'combinator') {
-      prev = node
-    } else if (isGlobalNode(n)) {
-      node = prev
+    }
+
+    if (isDeepCombinator(n)) {
       return false
     }
   })
@@ -47,7 +50,7 @@ const addScopedIdPlugin = postcss.plugin('add-scoped-id', options => {
         }))
       }
 
-      removeGlobalNode(selector)
+      replaceDeepCombinator(selector)
     })
   })
 

--- a/test/modules/add-scoped-id.spec.js
+++ b/test/modules/add-scoped-id.spec.js
@@ -92,53 +92,11 @@ describe('add scoped id module', () => {
     })
   })
 
-  it('should not scope when there is :global pseudo class in ancestors', done => {
+  it('should add scope attribute the selector before >>> combinator', done => {
     test(
       'data-v-1',
-      [
-        ':global p {}',
-        ':global ul li {}'
-      ].join('\n'),
-      [
-        ' p {}',
-        ' ul li {}'
-      ].join('\n')
-    ).then(done)
-  })
-
-  it('should not scope selector having :global pseudo class', done => {
-    test(
-      'data-v-1',
-      '.foo:global {}',
-      '.foo {}'
-    ).then(done)
-  })
-
-  it('should scope parent node of :global pseudo class', done => {
-    test(
-      'data-v-1',
-      [
-        '.foo .bar :global .baz {}',
-        '.foo .bar:global {}'
-      ].join('\n'),
-      [
-        '.foo .bar[data-v-1]  .baz {}',
-        '.foo[data-v-1] .bar {}'
-      ].join('\n')
-    ).then(done)
-  })
-
-  it('should not add scope attribute to combinator', done => {
-    test(
-      'data-v-1',
-      [
-        '.foo + :global .bar {}',
-        '.foo :global > .bar {}'
-      ].join('\n'),
-      [
-        '.foo[data-v-1] +  .bar {}',
-        '.foo[data-v-1]  > .bar {}'
-      ].join('\n')
+      '.foo .bar >>> .baz {}',
+      '.foo .bar[data-v-1] .baz {}'
     ).then(done)
   })
 })
@@ -148,14 +106,8 @@ function test (id, input, expected, map) {
     sourceMap: !!map,
     fileName: 'test.css',
     prevMap: map === true ? null : map
-  }).then(
-    result => {
-      expect(result.css).toBe(expected)
-      return result
-    },
-    err => {
-      console.error(err)
-      throw err
-    }
-  )
+  }).then(result => {
+    expect(result.css).toBe(expected)
+    return result
+  })
 }


### PR DESCRIPTION
I just realized there is a `>>>` combinator for applying styles any descendant components in Shadow DOM. I think it would be better to use more standard approach.

With `>>>` combinator, it works like `:global` but it requires an ancestor element as it actually is a combinator.

ref #23 