### PR TITLE
Add options for base styles path

### DIFF
--- a/lib/template-loader.js
+++ b/lib/template-loader.js
@@ -37,15 +37,14 @@ module.exports = function (content) {
   if (stylePath) {
     if (!options.scoped) {
       builder.addLine(`
-        var styles = require('${stylePath}')
+        var styles = require('${options.stylesFolder ? options.stylesFolder + stylePath : stylePath}')
       `)
     } else {
       const loaderPath = require.resolve('./scoped-style-loader.js')
       const req = loaderUtils.stringifyRequest(
         this,
-        `${loaderPath}?id=${id}!${stylePath}`
+        `${loaderPath}?id=${id}!${options.stylesFolder ? options.stylesFolder + stylePath : stylePath}`
       )
-
       builder.addLine(`
         var styles = require(${req})
       `)


### PR DESCRIPTION
The improvement is to change your flow from relative folder to file name if you want:

**before**:

```
{
        test: /\.html$/,
        loader: 'vue-template-loader',
        options: {
            scoped: true
        }
    }
```

```
import { Component, Vue } from 'vue-property-decorator';

import Template from './app.component.html?style=../../dist/css/scripts/app.component.css';

@Template
@Component
export class AppComponent extends Vue {
}

```

**after**:

```
{
        test: /\.html$/,
        loader: 'vue-template-loader',
        options: {
            scoped: true,
            stylesFolder: '../../dist/css/scripts/'
        }
    }
```

```
import { Component, Vue } from 'vue-property-decorator';

import Template from './app.component.html?style=app.component.css';

@Template
@Component
export class AppComponent extends Vue {
}
```

Why? Sometimes you don't want to compile your style preprocesor with webpack and you have all the files compiled separately, this with help also on other workflows.