### PR TITLE
Add support for /deep/ selector in sass style files.

### DIFF
--- a/lib/modules/add-scoped-id.js
+++ b/lib/modules/add-scoped-id.js
@@ -3,12 +3,28 @@ const postcss = require('postcss')
 const selectorParser = require('postcss-selector-parser')
 
 function isDeepCombinator (node) {
-  return node.type === 'combinator' && (node.toString().trim() === '>>>' || node.toString().trim() === '/deep/')
+  if (node.type === 'combinator' && node.toString().trim() === '>>>') {
+    return true
+  }
+  if (node.type === 'tag' && node.toString().trim() === '/deep/') {
+    return true
+  }
+}
+
+function isSassDeepCombinator (node) {
+  return node.type === 'tag' && node.toString().trim() === '/deep/'
 }
 
 function replaceDeepCombinator (selector) {
   selector.each(n => {
-    if (isDeepCombinator(n)) {
+    if (isSassDeepCombinator(n)) {
+      const next = n.next()
+      if (next.type === 'combinator' && next.value === ' ') {
+        console.log('removed next')
+        next.remove()
+      }
+      n.remove()
+    } else if (isDeepCombinator(n)) {
       // Use descendant combinator instead of deep combinator
       n.replaceWith(selectorParser.combinator({
         value: ' '
@@ -42,15 +58,16 @@ const addScopedIdPlugin = postcss.plugin('add-scoped-id', options => {
 
   const selectorTransformer = selectorParser(selectors => {
     selectors.each(selector => {
+      console.log(selector)
       const target = getTargetNode(selector)
-
+      replaceDeepCombinator(selector)
       if (target) {
+        console.log(selector)
         selector.insertAfter(target, selectorParser.attribute({
           attribute: options.id
         }))
       }
 
-      replaceDeepCombinator(selector)
     })
   })
 

--- a/lib/modules/add-scoped-id.js
+++ b/lib/modules/add-scoped-id.js
@@ -20,7 +20,6 @@ function replaceDeepCombinator (selector) {
     if (isSassDeepCombinator(n)) {
       const next = n.next()
       if (next.type === 'combinator' && next.value === ' ') {
-        console.log('removed next')
         next.remove()
       }
       n.remove()
@@ -58,11 +57,9 @@ const addScopedIdPlugin = postcss.plugin('add-scoped-id', options => {
 
   const selectorTransformer = selectorParser(selectors => {
     selectors.each(selector => {
-      console.log(selector)
       const target = getTargetNode(selector)
       replaceDeepCombinator(selector)
       if (target) {
-        console.log(selector)
         selector.insertAfter(target, selectorParser.attribute({
           attribute: options.id
         }))

--- a/lib/modules/add-scoped-id.js
+++ b/lib/modules/add-scoped-id.js
@@ -3,7 +3,7 @@ const postcss = require('postcss')
 const selectorParser = require('postcss-selector-parser')
 
 function isDeepCombinator (node) {
-  return node.type === 'combinator' && node.toString().trim() === '>>>'
+  return node.type === 'combinator' && (node.toString().trim() === '>>>' || node.toString().trim() === '/deep/')
 }
 
 function replaceDeepCombinator (selector) {


### PR DESCRIPTION
Since sass parser doesn't allow '>>>' selector, vue-loader uses /deep/ instead.
I just looked into vue-loader's code and implement it in this loader.
