### PR TITLE
feat: Support uri fragment in transformed require

### DIFF
--- a/lib/modules/template-compiler.js
+++ b/lib/modules/template-compiler.js
@@ -93,7 +93,7 @@ function rewriteAsset (attr) {
     const uriParts = evalUriParts(value)
 
     attr.value =
-      uriParts.uriFragment == null
+      !uriParts.uriFragment
         ? `require(${value})`
         :
         // support uri fragment case by excluding it from
@@ -117,7 +117,7 @@ function evalUriParts(candidate) {
     uriFragment: null,
     uriPath: null
   }
-  if (candidate !== null && candidate !== undefined) {
+  if (candidate) {
     // if we have enough input to eliminate the sourrounding quotes
     const fullUri =
       candidate.length > 2 ? candidate.slice(1, candidate.length - 1) : null
@@ -125,7 +125,7 @@ function evalUriParts(candidate) {
     if ('string' === typeof fullUri && loaderUtils.isUrlRequest(fullUri)) {
       // check is an uri
       const uri = url.parse(fullUri) // take apart the uri
-      if (uri.hash !== null && uri.hash !== undefined) {
+      if (uri.hash) {
         // if there is a fragment part
         // memo the fragment part(contains the  leading #)
         returnValue.uriFragment = uri.hash

--- a/lib/modules/template-compiler.js
+++ b/lib/modules/template-compiler.js
@@ -107,7 +107,7 @@ function toFunction (code) {
 }
 
 /**
- * ktsn/vue-template-loader#41 Support uri fragment in transformed require
+ * ktsn/vue-template-loader#49 Support uri fragment in transformed require
  * @param candidate {string}
  * @returns {{uriFragment: string, uriPath: string}}
  */

--- a/lib/modules/template-compiler.js
+++ b/lib/modules/template-compiler.js
@@ -2,6 +2,8 @@ const assert = require('assert')
 const compiler = require('vue-template-compiler')
 const transpile = require('vue-template-es2015-compiler')
 const SourceMapGenerator = require('source-map').SourceMapGenerator
+const url = require('url')
+const loaderUtils = require('loader-utils')
 
 const empty =
   `var render = ${toFunction('')}\n` +
@@ -87,10 +89,50 @@ function rewriteAsset (attr) {
     if (first === '~') {
       value = '"' + value.slice(2)
     }
-    attr.value = `require(${value})`
+
+    const uriParts = evalUriParts(value)
+
+    attr.value =
+      uriParts.uriFragment == null
+        ? `require(${value})`
+        :
+        // support uri fragment case by excluding it from
+        // the require and instead appending it as string
+        `require("${uriParts.uriPath}") + "${uriParts.uriFragment}"`
   }
 }
 
 function toFunction (code) {
   return `function(){${code}}`
+}
+
+/**
+ * ktsn/vue-template-loader#41 Support uri fragment in transformed require
+ * @param candidate {string}
+ * @returns {{uriFragment: string, uriPath: string}}
+ */
+function evalUriParts(candidate) {
+  // initialize return value
+  const returnValue = {
+    uriFragment: null,
+    uriPath: null
+  }
+  if (candidate !== null && candidate !== undefined) {
+    // if we have enough input to eliminate the sourrounding quotes
+    const fullUri =
+      candidate.length > 2 ? candidate.slice(1, candidate.length - 1) : null
+    // isUrlRequest throws TypeError if url is not of type string
+    if ('string' === typeof fullUri && loaderUtils.isUrlRequest(fullUri)) {
+      // check is an uri
+      const uri = url.parse(fullUri) // take apart the uri
+      if (uri.hash !== null && uri.hash !== undefined) {
+        // if there is a fragment part
+        // memo the fragment part(contains the  leading #)
+        returnValue.uriFragment = uri.hash
+        // memo the uri minus the fragment part
+        returnValue.uriPath = uri.path
+      }
+    }
+  }
+  return returnValue
 }

--- a/test/modules/template-compiler.spec.js
+++ b/test/modules/template-compiler.spec.js
@@ -40,7 +40,7 @@ describe('template-compiler', () => {
   })
 
   /**
-   * ktsn/vue-template-loader#41 Support uri fragment in transformed require
+   * ktsn/vue-template-loader#49 Support uri fragment in transformed require
    */
   it('supports uri fragment in transformed require', () => {
     const src = //
@@ -56,7 +56,7 @@ describe('template-compiler', () => {
   })
 
   /**
-   * ktsn/vue-template-loader#41 Support uri fragment in transformed require
+   * ktsn/vue-template-loader#49 Support uri fragment in transformed require
    */
   it('when too short uri then empty require', () => {
     const src = //

--- a/test/modules/template-compiler.spec.js
+++ b/test/modules/template-compiler.spec.js
@@ -38,4 +38,36 @@ describe('template-compiler', () => {
     expect(pos.line).toBe(1)
     expect(pos.column).toBe(0)
   })
+
+  /**
+   * ktsn/vue-template-loader#41 Support uri fragment in transformed require
+   */
+  it('supports uri fragment in transformed require', () => {
+    const src = //
+    '<svg>\
+      <use href="~@svg/file.svg#fragment"></use>\
+    </svg>'
+    const actual = compile(src, {
+      transformToRequire: {
+        use: 'href'
+      }
+    })
+    expect(actual.code).toMatch(/"href":require\("@svg\/file.svg"\) \+ "#fragment"/)
+  })
+
+  /**
+   * ktsn/vue-template-loader#41 Support uri fragment in transformed require
+   */
+  it('when too short uri then empty require', () => {
+    const src = //
+    '<svg>\
+      <use href="~"></use>\
+    </svg>'
+    const actual = compile(src, {
+      transformToRequire: {
+        use: 'href'
+      }
+    })
+    expect(actual.code).toMatch(/"href":require\(""\)/)
+  })
 })


### PR DESCRIPTION
Hello katashin,

My case for this PR is a svg within a html based vue component, where i deployed `vue-template-loader` for this usage. In this html i put a svg element as in
```html
<svg>
    <use href="~@svg/menu.svg#menu"></use>
</svg>
```
After banging my head over webpack's `Module not found: Error` i found out that this case may be covered by `vue-template-loader`, which is the purpose of this PR. Root cause is that the whole href is generated by `vue-template-loader` and as-is is required by webpack; this must fail because the whole href - including the uri fragment `#menu` - is not part of any mapped physical file location of such an svg.  

Kindly request you to consider this PR; If the PR does not meet your accepted standards, after your feedback i would alternatively like to bring that in as a seperate feature request issue.
